### PR TITLE
refactor: cleanup and simplify codebase

### DIFF
--- a/src/mdeck/api.ts
+++ b/src/mdeck/api.ts
@@ -30,9 +30,9 @@ export function createSlideshow(options: SlideshowOptions = {}, callback?: (slid
 
   const slideshow = new Slideshow(events, _dom, options, (ss) => {
     const slideshowView = new SlideshowView(events, _dom, options, ss);
-    const controller = (options.controller as DefaultController)
-      || new DefaultController(events, _dom, slideshowView, (options.navigation ?? {}) as Record<string, unknown>);
-    void controller;
+    if (!options.controller) {
+      new DefaultController(events, _dom, slideshowView, (options.navigation ?? {}) as Record<string, unknown>);
+    }
     callback?.(ss);
   });
 

--- a/src/mdeck/components/styler/styler.ts
+++ b/src/mdeck/components/styler/styler.ts
@@ -44,15 +44,9 @@ export const styler = {
 };
 
 function getRemarkStylesheet(): CSSStyleSheet | undefined {
-  for (let i = 0; i < document.styleSheets.length; i++) {
-    if (document.styleSheets[i].title === 'remark') return document.styleSheets[i];
-  }
-  return undefined;
+  return Array.from(document.styleSheets).find((s) => s.title === 'remark');
 }
 
 function getPageRule(stylesheet: CSSStyleSheet): CSSRule | undefined {
-  for (let i = 0; i < stylesheet.cssRules.length; i++) {
-    if (stylesheet.cssRules[i] instanceof CSSPageRule) return stylesheet.cssRules[i];
-  }
-  return undefined;
+  return Array.from(stylesheet.cssRules).find((r) => r instanceof CSSPageRule);
 }

--- a/src/mdeck/controllers/inputs/location.ts
+++ b/src/mdeck/controllers/inputs/location.ts
@@ -1,7 +1,6 @@
 import type EventEmitter from 'eventemitter3';
 import type { Dom } from '../../dom.js';
 import type { SlideshowView } from '../../views/slideshowView.js';
-import { hasClass } from '../../utils.js';
 
 export function register(events: EventEmitter, dom: Dom, slideshowView: SlideshowView): void {
   if (slideshowView.isEmbedded()) {
@@ -19,7 +18,7 @@ export function register(events: EventEmitter, dom: Dom, slideshowView: Slidesho
   }
 
   function updateHash(slideNoOrName: string | number) {
-    if (hasClass(slideshowView.containerElement, 'remark-presenter-mode')) {
+    if (slideshowView.containerElement.classList.contains('remark-presenter-mode')) {
       dom.setLocationHash('#p' + slideNoOrName);
     } else {
       dom.setLocationHash('#' + slideNoOrName);

--- a/src/mdeck/controllers/inputs/location.ts
+++ b/src/mdeck/controllers/inputs/location.ts
@@ -14,7 +14,7 @@ export function register(events: EventEmitter, dom: Dom, slideshowView: Slidesho
   }
 
   function navigateByHash() {
-    const slideNoOrName = (dom.getLocationHash() || '').substr(1);
+    const slideNoOrName = (dom.getLocationHash() || '').slice(1);
     events.emit('gotoSlide', slideNoOrName);
   }
 

--- a/src/mdeck/lexer.ts
+++ b/src/mdeck/lexer.ts
@@ -118,7 +118,7 @@ function getTextInBrackets(src: string, offset: number): string | undefined {
     depth += (chr === '[' ? 1 : chr === ']' ? -1 : 0);
   }
   if (depth === 0) {
-    return src.substr(offset, pos - offset - 1);
+    return src.slice(offset, pos - 1);
   }
   return undefined;
 }

--- a/src/mdeck/models/slideshow.ts
+++ b/src/mdeck/models/slideshow.ts
@@ -49,6 +49,8 @@ export class Slideshow {
   on!: (...args: Parameters<EventEmitter['on']>) => this;
 
   private _slides: Slide[] = [];
+  private _slidesByName: Record<string, Slide> = {};
+  private _slidesByNumber: Record<number, Slide[]> = {};
   private _links: Record<string, { href: string; title?: string }> = {};
 
   constructor(private _events: EventEmitter, private _dom: Dom, private _options: SlideshowOptions, callback?: (slideshow: Slideshow) => void) {
@@ -70,8 +72,8 @@ export class Slideshow {
   getLinks() { return this._links; }
   getSlides(): Slide[] { return [...this._slides]; }
   getSlideCount(): number { return this._slides.length; }
-  getSlideByName(name: string): Slide | undefined { return (this._slides as unknown as { byName: Record<string, Slide> }).byName?.[name]; }
-  getSlidesByNumber(number: number): Slide[] | undefined { return (this._slides as unknown as { byNumber: Record<number, Slide[]> }).byNumber?.[number]; }
+  getSlideByName(name: string): Slide | undefined { return this._slidesByName[name]; }
+  getSlidesByNumber(number: number): Slide[] | undefined { return this._slidesByNumber[number]; }
 
   togglePresenterMode() { this._events.emit('togglePresenterMode'); }
   toggleHelp() { this._events.emit('toggleHelp'); }
@@ -94,7 +96,10 @@ export class Slideshow {
   getMarkdownRenderer(): ((markdown: string) => string | null | Promise<string | null>) | undefined { return this._options.markdownRenderer; }
 
   private _loadFromString(source: string): void {
-    this._slides = createSlides(source, this._options);
+    const { slides, byName, byNumber } = createSlides(source, this._options);
+    this._slides = slides;
+    this._slidesByName = byName;
+    this._slidesByNumber = byNumber;
     expandVariables(this._slides);
     this._links = {};
     this._slides.forEach((slide) => {
@@ -122,7 +127,7 @@ export class Slideshow {
   }
 }
 
-function createSlides(source: string, options: SlideshowOptions): Slide[] {
+function createSlides(source: string, options: SlideshowOptions): { slides: Slide[]; byName: Record<string, Slide>; byNumber: Record<number, Slide[]> } {
   const parser = new Parser();
   const parsed = parser.parse(source, macros, options);
   const slides: Slide[] = [];
@@ -130,9 +135,6 @@ function createSlides(source: string, options: SlideshowOptions): Slide[] {
   const byNumber: Record<number, Slide[]> = {};
   let layoutSlide: Slide | undefined;
   let slideNumber = 0;
-
-  (slides as unknown as { byName: Record<string, Slide>; byNumber: Record<number, Slide[]> }).byName = byName;
-  (slides as unknown as { byName: Record<string, Slide>; byNumber: Record<number, Slide[]> }).byNumber = byNumber;
 
   parsed.forEach((parsedSlide, i) => {
     let template: Slide | undefined;
@@ -179,13 +181,10 @@ function createSlides(source: string, options: SlideshowOptions): Slide[] {
           byNumber[slideNumber].push(slideViewModel);
         }
       }
-      if (parsedSlide.properties.name) {
-        (slides as unknown as { byName: Record<string, Slide> }).byName[parsedSlide.properties.name] = slideViewModel;
-      }
     }
   });
 
-  return slides;
+  return { slides, byName, byNumber };
 }
 
 function expandVariables(slides: Slide[]) {

--- a/src/mdeck/models/slideshow/navigation.ts
+++ b/src/mdeck/models/slideshow/navigation.ts
@@ -83,7 +83,7 @@ export function applyNavigation(self: Slideshow, events: EventEmitter, options: 
     if (slideNo.toString() === slideNoOrName) return slideNo - 1;
     if (/^p\d+$/.test(slideNoOrName)) {
       events.emit('forcePresenterMode');
-      return parseInt(slideNoOrName.substr(1), 10) - 1;
+      return parseInt(slideNoOrName.slice(1), 10) - 1;
     }
     const slide = self.getSlideByName(slideNoOrName);
     if (slide) return slide.getSlideIndex();

--- a/src/mdeck/parser.ts
+++ b/src/mdeck/parser.ts
@@ -118,7 +118,7 @@ function extractProperties(source: string, properties: Record<string, string>): 
   const propertyFinder = /^\n*([-\w]+):([^$\n]*)|\n*(?:<!--\s*)([-\w]+):([^$\n]*?)(?:\s*-->)/i;
   let match: RegExpExecArray | null;
   while ((match = propertyFinder.exec(source)) !== null) {
-    source = source.substr(0, match.index) + source.substr(match.index + match[0].length);
+    source = source.slice(0, match.index) + source.slice(match.index + match[0].length);
     if (match[1] !== undefined) {
       properties[match[1].trim()] = match[2].trim();
     } else {

--- a/src/mdeck/parser.ts
+++ b/src/mdeck/parser.ts
@@ -29,7 +29,6 @@ export type MacroMap = Record<string, MacroFn>;
 
 export class Parser {
   parse(src: string, macros: MacroMap = {}, options: ParserOptions = {}): ParsedSlide[] {
-    const self = this;
     const lexer = new Lexer();
     const tokens = lexer.lex(cleanInput(src));
     const slides: ParsedSlide[] = [];
@@ -54,7 +53,7 @@ export class Parser {
           }
           const value = macro.apply(token.obj, token.args);
           if (typeof value === 'string') {
-            const parsed = self.parse(value, macros);
+            const parsed = this.parse(value, macros);
             appendTo(stack[stack.length - 1], parsed[0].content[0]);
           } else {
             appendTo(stack[stack.length - 1], value === undefined ? '' : String(value));

--- a/src/mdeck/resources.ts
+++ b/src/mdeck/resources.ts
@@ -1,6 +1,7 @@
 import documentStyles from '../styles/mdeck.css?raw';
+import pkg from '../../package.json';
 
-export const version = '1.0.0';
+export const version = pkg.version;
 export { documentStyles };
 
 export const containerLayout = `<div class="remark-notes-area">

--- a/src/mdeck/scaler.ts
+++ b/src/mdeck/scaler.ts
@@ -1,7 +1,6 @@
 import type EventEmitter from 'eventemitter3';
 import type { Slideshow } from './models/slideshow.js';
 
-const referenceWidth = 908;
 const referenceHeight = 681;
 
 interface Ratio { width: number; height: number; ratio: number }

--- a/src/mdeck/scaler.ts
+++ b/src/mdeck/scaler.ts
@@ -3,7 +3,6 @@ import type { Slideshow } from './models/slideshow.js';
 
 const referenceWidth = 908;
 const referenceHeight = 681;
-const referenceRatio = referenceWidth / referenceHeight;
 
 interface Ratio { width: number; height: number; ratio: number }
 interface Dimensions { width: number; height: number }
@@ -51,7 +50,7 @@ function getRatio(slideshow: Slideshow): Ratio {
 
 function getDimensions(ratio: Ratio): Dimensions {
   return {
-    width: Math.floor(referenceWidth / referenceRatio * ratio.ratio),
+    width: Math.floor(referenceHeight * ratio.ratio),
     height: referenceHeight,
   };
 }

--- a/src/mdeck/utils.ts
+++ b/src/mdeck/utils.ts
@@ -1,27 +1,3 @@
-export function addClass(element: Element, className: string): void {
-  element.className = getClasses(element).concat([className]).join(' ');
-}
-
-export function removeClass(element: Element, className: string): void {
-  element.className = getClasses(element).filter((k) => k !== className).join(' ');
-}
-
-export function toggleClass(element: Element, className: string): void {
-  const classes = getClasses(element);
-  const index = classes.indexOf(className);
-  if (index !== -1) classes.splice(index, 1);
-  else classes.push(className);
-  element.className = classes.join(' ');
-}
-
-export function getClasses(element: Element): string[] {
-  return element.className.split(' ').filter((s) => s !== '');
-}
-
-export function hasClass(element: Element, className: string): boolean {
-  return getClasses(element).includes(className);
-}
-
 export function getPrefixedProperty<T>(element: Record<string, T>, propertyName: string): T | undefined {
   const cap = propertyName[0].toUpperCase() + propertyName.slice(1);
   return element[propertyName] || (element as Record<string, T>)['moz' + cap] || (element as Record<string, T>)['webkit' + cap];

--- a/src/mdeck/views/notesView.ts
+++ b/src/mdeck/views/notesView.ts
@@ -57,7 +57,7 @@ export class NotesView {
     Array.from(links).forEach((link) => {
       link.addEventListener('click', (e) => {
         e.preventDefault();
-        const command = (e.target as HTMLAnchorElement).hash.substr(1);
+        const command = (e.target as HTMLAnchorElement).hash.slice(1);
         commands[command]?.();
       });
     });

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -17,7 +17,7 @@ export class SlideView {
   originalBackgroundPosition?: string;
   private slideNumber: SlideNumber;
 
-  constructor(private events: EventEmitter, private slideshow: Slideshow, private scaler: Scaler, private slide: Slide) {
+  constructor(events: EventEmitter, private slideshow: Slideshow, private scaler: Scaler, private slide: Slide) {
     this.slideNumber = new SlideNumber(slide, slideshow);
     this.configureElements();
     this.updateDimensions();

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -57,7 +57,7 @@ export class SlideView {
     this.scalingElement.className = 'remark-slide-scaler';
 
     this.element = createSlideElement(this.slide);
-    this.contentElement = createContentElement(this.events, this.slideshow, this.slide);
+    this.contentElement = createContentElement(this.slideshow, this.slide);
     this.notesElement = createNotesElement(this.slideshow, this.slide.notes);
 
     this.contentElement.appendChild(this.slideNumber.element);
@@ -107,7 +107,7 @@ function createSlideElement(slide: Slide): HTMLElement {
   return element;
 }
 
-function createContentElement(_events: EventEmitter, slideshow: Slideshow, slide: Slide): HTMLElement {
+function createContentElement(slideshow: Slideshow, slide: Slide): HTMLElement {
   const element = document.createElement('div');
   if (slide.properties.name) element.id = 'slide-' + slide.properties.name;
   styleContentElement(slideshow, element, slide.properties);

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -222,7 +222,7 @@ function highlightBlockSpans(block: HTMLElement, highlightSpans: boolean | RegEx
   Array.from(block.childNodes).forEach((node) => {
     if (node instanceof HTMLElement) {
       node.innerHTML = node.innerHTML.replace(pattern, (m, e, c) => {
-        if (e === '\\') return m.substr(1);
+        if (e === '\\') return m.slice(1);
         return e + `<span class="remark-code-span-highlighted">${c}</span>`;
       });
     }

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -4,7 +4,6 @@ import type { Slide } from '../models/slide.js';
 import type { Scaler } from '../scaler.js';
 import { convertMarkdown, convertMarkdownAsync } from '../converter.js';
 import { engine as highlighter } from '../highlighter.js';
-import { addClass } from '../utils.js';
 import { SlideNumber } from '../components/slide-number/slide-number.js';
 
 export class SlideView {
@@ -39,13 +38,13 @@ export class SlideView {
   }
 
   show(): void {
-    addClass(this.containerElement, 'remark-visible');
+    this.containerElement.classList.add('remark-visible');
     this.containerElement.classList.remove('remark-fading');
   }
 
   hide(): void {
     this.containerElement.classList.remove('remark-visible');
-    addClass(this.containerElement, 'remark-fading');
+    this.containerElement.classList.add('remark-fading');
     setTimeout(() => this.containerElement.classList.remove('remark-fading'), 1000);
   }
 
@@ -103,7 +102,7 @@ export class SlideView {
 function createSlideElement(slide: Slide): HTMLElement {
   const element = document.createElement('div');
   element.className = 'remark-slide';
-  if (slide.properties.continued === 'true') addClass(element, 'remark-slide-incremental');
+  if (slide.properties.continued === 'true') element.classList.add('remark-slide-incremental');
   return element;
 }
 
@@ -130,11 +129,11 @@ function createContentElement(slideshow: Slideshow, slide: Slide): HTMLElement {
 
 function styleContentElement(slideshow: Slideshow, element: HTMLElement, properties: Record<string, string>): void {
   element.className = '';
-  addClass(element, 'remark-slide-content');
-  (properties['class'] || '').split(/,| /).filter(Boolean).forEach((c) => addClass(element, c));
+  element.classList.add('remark-slide-content');
+  (properties['class'] || '').split(/,| /).filter(Boolean).forEach((c) => element.classList.add(c));
 
   const highlightStyle = properties['highlight-style'] || slideshow.getHighlightStyle();
-  if (highlightStyle) addClass(element, 'hljs-' + highlightStyle);
+  if (highlightStyle) element.classList.add('hljs-' + highlightStyle);
 
   if (properties['background-image']) element.style.backgroundImage = properties['background-image'];
   if (properties['background-color']) element.style.backgroundColor = properties['background-color'];
@@ -171,7 +170,7 @@ function highlightCodeBlocks(content: HTMLElement, slideshow: Slideshow): void {
     if (block.className === '') block.className = slideshow.getHighlightLanguage();
 
     if (block.parentElement?.tagName !== 'PRE') {
-      addClass(block, 'remark-inline-code');
+      block.classList.add('remark-inline-code');
       if (highlightInline) highlighter.highlightElement(block);
       return;
     }
@@ -186,7 +185,7 @@ function highlightCodeBlocks(content: HTMLElement, slideshow: Slideshow): void {
     if (highlightLines) highlightBlockLines(block, meta.highlightedLines);
     if (highlightSpans) highlightBlockSpans(block, highlightSpans);
 
-    addClass(block, 'remark-code');
+    block.classList.add('remark-code');
   });
 }
 
@@ -206,7 +205,7 @@ function wrapLines(block: HTMLElement): void {
 }
 
 function highlightBlockLines(block: HTMLElement, lines: number[]): void {
-  lines.forEach((i) => addClass(block.childNodes[i] as HTMLElement, 'remark-code-line-highlighted'));
+  lines.forEach((i) => (block.childNodes[i] as HTMLElement).classList.add('remark-code-line-highlighted'));
 }
 
 function highlightBlockSpans(block: HTMLElement, highlightSpans: boolean | RegExp): void {

--- a/src/mdeck/views/slideshowView.ts
+++ b/src/mdeck/views/slideshowView.ts
@@ -7,7 +7,7 @@ import { Scaler } from '../scaler.js';
 import { containerLayout } from '../resources.js';
 import { printing } from '../components/printing/printing.js';
 import { Timer } from '../components/timer/timer.js';
-import { toggleClass, addClass, removeClass, hasClass, getPrefixedProperty } from '../utils.js';
+import { getPrefixedProperty } from '../utils.js';
 
 export class SlideshowView {
   containerElement!: HTMLElement;
@@ -37,38 +37,38 @@ export class SlideshowView {
     events.on('slidesChanged', () => this.updateSlideViews());
 
     events.on('hideSlide', (slideIndex: number) => {
-      Array.from(this.elementArea.getElementsByClassName('remark-fading')).forEach((s) => removeClass(s as HTMLElement, 'remark-fading'));
+      Array.from(this.elementArea.getElementsByClassName('remark-fading')).forEach((s) => (s as HTMLElement).classList.remove('remark-fading'));
       this.hideSlide(slideIndex);
     });
 
     events.on('showSlide', (slideIndex: number) => this.showSlide(slideIndex));
 
     events.on('forcePresenterMode', () => {
-      if (!hasClass(this.containerElement, 'remark-presenter-mode')) {
-        toggleClass(this.containerElement, 'remark-presenter-mode');
+      if (!this.containerElement.classList.contains('remark-presenter-mode')) {
+        this.containerElement.classList.toggle('remark-presenter-mode');
         this.scaleElements();
         printing.setPageOrientation('landscape');
       }
     });
 
     events.on('togglePresenterMode', () => {
-      toggleClass(this.containerElement, 'remark-presenter-mode');
+      this.containerElement.classList.toggle('remark-presenter-mode');
       this.scaleElements();
       events.emit('toggledPresenter', this.slideshow.getCurrentSlideIndex() + 1);
-      printing.setPageOrientation(hasClass(this.containerElement, 'remark-presenter-mode') ? 'portrait' : 'landscape');
+      printing.setPageOrientation(this.containerElement.classList.contains('remark-presenter-mode') ? 'portrait' : 'landscape');
     });
 
-    events.on('toggleHelp', () => toggleClass(this.containerElement, 'remark-help-mode'));
-    events.on('toggleBlackout', () => toggleClass(this.containerElement, 'remark-blackout-mode'));
-    events.on('toggleMirrored', () => toggleClass(this.containerElement, 'remark-mirrored-mode'));
+    events.on('toggleHelp', () => this.containerElement.classList.toggle('remark-help-mode'));
+    events.on('toggleBlackout', () => this.containerElement.classList.toggle('remark-blackout-mode'));
+    events.on('toggleMirrored', () => this.containerElement.classList.toggle('remark-mirrored-mode'));
 
     events.on('hideOverlay', () => {
-      removeClass(this.containerElement, 'remark-blackout-mode');
-      removeClass(this.containerElement, 'remark-help-mode');
+      this.containerElement.classList.remove('remark-blackout-mode');
+      this.containerElement.classList.remove('remark-help-mode');
     });
 
-    events.on('pause', () => toggleClass(this.containerElement, 'remark-pause-mode'));
-    events.on('resume', () => toggleClass(this.containerElement, 'remark-pause-mode'));
+    events.on('pause', () => this.containerElement.classList.toggle('remark-pause-mode'));
+    events.on('resume', () => this.containerElement.classList.toggle('remark-pause-mode'));
 
     this.handleFullscreen();
   }
@@ -79,10 +79,10 @@ export class SlideshowView {
 
   configureContainerElement(element: HTMLElement): void {
     this.containerElement = element;
-    addClass(element, 'remark-container');
+    element.classList.add('remark-container');
 
     if (element === this.dom.getBodyElement()) {
-      addClass(this.dom.getHTMLElement(), 'remark-container');
+      this.dom.getHTMLElement().classList.add('remark-container');
       forwardEvents(this.events, window, ['hashchange', 'resize', 'keydown', 'keypress', 'mousewheel', 'message', 'DOMMouseScroll']);
       forwardEvents(this.events, element, ['touchstart', 'touchmove', 'touchend', 'click', 'contextmenu']);
     } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

A series of focused refactors to clean up and simplify the codebase. All 131 tests pass throughout.

## Changes

### 1. Replace deprecated `substr()` with `slice()`
`String.prototype.substr()` is deprecated. Replaced all usages with the standard `slice()` across `lexer.ts`, `parser.ts`, `navigation.ts`, `slideView.ts`, `notesView.ts`, and `location.ts`.

### 2. Remove `const self = this` alias in `parser.ts`
The `self` alias was unnecessary since the `forEach` callback already uses an arrow function which preserves `this` context.

### 3. Extract `byName`/`byNumber` maps from the slides array
The pattern of attaching hidden `byName` and `byNumber` dictionaries directly onto the `Slide[]` array using unsafe `as unknown as` type casts was a significant code smell. Replaced with proper private fields `_slidesByName` and `_slidesByNumber` on the `Slideshow` class, and `createSlides()` now returns a typed `{ slides, byName, byNumber }` object. Also removed a duplicate `byName` assignment that was redundant.

### 4. Remove unused `_events` param from `createContentElement`
The first parameter was prefixed with `_` to suppress the lint warning but was never used. Removed it entirely.

### 5. Simplify `styler.ts` loops with `Array.from().find()`
Replaced old-style indexed `for` loops in `getRemarkStylesheet()` and `getPageRule()` with idiomatic `Array.from(...).find(...)`.

### 6. Simplify dimension calculation in `scaler.ts`
`referenceWidth / referenceRatio * ratio.ratio` algebraically simplifies to `referenceHeight * ratio.ratio` (since `referenceRatio = referenceWidth / referenceHeight`). Removed the now-unused `referenceRatio` constant.

### 7. Clean up controller initialization in `api.ts`
Replaced the `void controller` pattern (assign to variable, then suppress unused-variable lint with `void`) with a straightforward conditional: only instantiate `DefaultController` when no custom controller is provided.

### 8. Replace custom class utils with native `classList` API
`addClass`, `removeClass`, `toggleClass`, `hasClass`, and `getClasses` in `utils.ts` were re-implementations of the native `Element.classList` API. Replaced all call sites with direct `classList.add/remove/toggle/contains` calls and removed the now-unused helpers. `getPrefixedProperty` is kept as it still serves a purpose for vendor-prefix feature detection.

### 9. Derive `version` from `package.json`
The hardcoded version string `'1.0.0'` in `resources.ts` was wrong (package.json has `0.16.1`). Now imported directly from `package.json` — enabled `resolveJsonModule` in `tsconfig.json` to support this.