### PR TITLE
feat: add mdeck-* CSS class prefix alongside remark-* (backward compat)

### DIFF
--- a/src/mdeck/components/slide-number/slide-number.ts
+++ b/src/mdeck/components/slide-number/slide-number.ts
@@ -6,7 +6,7 @@ export class SlideNumber {
 
   constructor(slide: Slide, slideshow: Slideshow) {
     this.element = document.createElement('div');
-    this.element.className = 'remark-slide-number';
+    this.element.className = 'remark-slide-number mdeck-slide-number';
     if (slideshow.getShowSlideNumber()) {
       this.element.innerHTML = formatSlideNumber(slide, slideshow);
     } else {

--- a/src/mdeck/components/styler/styler.ts
+++ b/src/mdeck/components/styler/styler.ts
@@ -7,7 +7,7 @@ export const styler = {
     const head = document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
     style.type = 'text/css';
-    style.title = 'remark';
+    style.title = 'mdeck';
     const css = documentStyles;
     style.innerHTML = css;
     head.insertBefore(style, head.firstChild);
@@ -44,7 +44,7 @@ export const styler = {
 };
 
 function getRemarkStylesheet(): CSSStyleSheet | undefined {
-  return Array.from(document.styleSheets).find((s) => s.title === 'remark');
+  return Array.from(document.styleSheets).find((s) => s.title === 'mdeck' || s.title === 'remark');
 }
 
 function getPageRule(stylesheet: CSSStyleSheet): CSSRule | undefined {

--- a/src/mdeck/controllers/inputs/location.ts
+++ b/src/mdeck/controllers/inputs/location.ts
@@ -18,7 +18,7 @@ export function register(events: EventEmitter, dom: Dom, slideshowView: Slidesho
   }
 
   function updateHash(slideNoOrName: string | number) {
-    if (slideshowView.containerElement.classList.contains('remark-presenter-mode')) {
+    if (slideshowView.containerElement.classList.contains('mdeck-presenter-mode')) {
       dom.setLocationHash('#p' + slideNoOrName);
     } else {
       dom.setLocationHash('#' + slideNoOrName);

--- a/src/mdeck/resources.ts
+++ b/src/mdeck/resources.ts
@@ -4,35 +4,35 @@ import pkg from '../../package.json';
 export const version = pkg.version;
 export { documentStyles };
 
-export const containerLayout = `<div class="remark-notes-area">
-  <div class="remark-top-area">
-    <div class="remark-toolbar">
-      <a class="remark-toolbar-link" href="#increase">+</a>
-      <a class="remark-toolbar-link" href="#decrease">-</a>
-      <span class="remark-toolbar-timer"></span>
+export const containerLayout = `<div class="remark-notes-area mdeck-notes-area">
+  <div class="remark-top-area mdeck-top-area">
+    <div class="remark-toolbar mdeck-toolbar">
+      <a class="remark-toolbar-link mdeck-toolbar-link" href="#increase">+</a>
+      <a class="remark-toolbar-link mdeck-toolbar-link" href="#decrease">-</a>
+      <span class="remark-toolbar-timer mdeck-toolbar-timer"></span>
     </div>
   </div>
-  <div class="remark-bottom-area">
-    <div class="remark-notes-current-area">
-      <div class="remark-toggle">Notes for current slide</div>
-      <div class="remark-notes"></div>
+  <div class="remark-bottom-area mdeck-bottom-area">
+    <div class="remark-notes-current-area mdeck-notes-current-area">
+      <div class="remark-toggle mdeck-toggle">Notes for current slide</div>
+      <div class="remark-notes mdeck-notes"></div>
     </div>
-    <div class="remark-notes-preview-area">
-      <div class="remark-toggle">Notes for next slide</div>
-      <div class="remark-notes-preview"></div>
+    <div class="remark-notes-preview-area mdeck-notes-preview-area">
+      <div class="remark-toggle mdeck-toggle">Notes for next slide</div>
+      <div class="remark-notes-preview mdeck-notes-preview"></div>
     </div>
   </div>
 </div>
-<div class="remark-slides-area"></div>
-<div class="remark-preview-area"></div>
-<div class="remark-backdrop"></div>
-<div class="remark-pause">
-  <div class="remark-pause-lozenge">
+<div class="remark-slides-area mdeck-slides-area"></div>
+<div class="remark-preview-area mdeck-preview-area"></div>
+<div class="remark-backdrop mdeck-backdrop"></div>
+<div class="remark-pause mdeck-pause">
+  <div class="remark-pause-lozenge mdeck-pause-lozenge">
     <span>Paused</span>
   </div>
 </div>
-<div class="remark-help">
-  <div class="remark-help-content">
+<div class="remark-help mdeck-help">
+  <div class="remark-help-content mdeck-help-content">
     <h1>Help</h1>
     <p><b>Keyboard shortcuts</b></p>
     <table class="light-keys">

--- a/src/mdeck/views/notesView.ts
+++ b/src/mdeck/views/notesView.ts
@@ -36,13 +36,13 @@ export class NotesView {
   }
 
   configureElements(): void {
-    this.notesElement = this.element.getElementsByClassName('remark-notes')[0] as HTMLElement;
-    this.notesPreviewElement = this.element.getElementsByClassName('remark-notes-preview')[0] as HTMLElement;
+    this.notesElement = this.element.getElementsByClassName('mdeck-notes')[0] as HTMLElement;
+    this.notesPreviewElement = this.element.getElementsByClassName('mdeck-notes-preview')[0] as HTMLElement;
 
     this.notesElement.addEventListener('wheel', (e) => e.stopPropagation());
     this.notesPreviewElement.addEventListener('wheel', (e) => e.stopPropagation());
 
-    const toolbar = this.element.getElementsByClassName('remark-toolbar')[0] as HTMLElement;
+    const toolbar = this.element.getElementsByClassName('mdeck-toolbar')[0] as HTMLElement;
     const links = toolbar.getElementsByTagName('a');
 
     const commands: Record<string, () => void> = {

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -38,22 +38,22 @@ export class SlideView {
   }
 
   show(): void {
-    this.containerElement.classList.add('remark-visible');
-    this.containerElement.classList.remove('remark-fading');
+    this.containerElement.classList.add('remark-visible', 'mdeck-visible');
+    this.containerElement.classList.remove('remark-fading', 'mdeck-fading');
   }
 
   hide(): void {
-    this.containerElement.classList.remove('remark-visible');
-    this.containerElement.classList.add('remark-fading');
-    setTimeout(() => this.containerElement.classList.remove('remark-fading'), 1000);
+    this.containerElement.classList.remove('remark-visible', 'mdeck-visible');
+    this.containerElement.classList.add('remark-fading', 'mdeck-fading');
+    setTimeout(() => this.containerElement.classList.remove('remark-fading', 'mdeck-fading'), 1000);
   }
 
   configureElements(): void {
     this.containerElement = document.createElement('div');
-    this.containerElement.className = 'remark-slide-container';
+    this.containerElement.className = 'remark-slide-container mdeck-slide-container';
 
     this.scalingElement = document.createElement('div');
-    this.scalingElement.className = 'remark-slide-scaler';
+    this.scalingElement.className = 'remark-slide-scaler mdeck-slide-scaler';
 
     this.element = createSlideElement(this.slide);
     this.contentElement = createContentElement(this.slideshow, this.slide);
@@ -101,8 +101,8 @@ export class SlideView {
 
 function createSlideElement(slide: Slide): HTMLElement {
   const element = document.createElement('div');
-  element.className = 'remark-slide';
-  if (slide.properties.continued === 'true') element.classList.add('remark-slide-incremental');
+  element.className = 'remark-slide mdeck-slide';
+  if (slide.properties.continued === 'true') element.classList.add('remark-slide-incremental', 'mdeck-slide-incremental');
   return element;
 }
 
@@ -129,7 +129,7 @@ function createContentElement(slideshow: Slideshow, slide: Slide): HTMLElement {
 
 function styleContentElement(slideshow: Slideshow, element: HTMLElement, properties: Record<string, string>): void {
   element.className = '';
-  element.classList.add('remark-slide-content');
+  element.classList.add('remark-slide-content', 'mdeck-slide-content');
   (properties['class'] || '').split(/,| /).filter(Boolean).forEach((c) => element.classList.add(c));
 
   const highlightStyle = properties['highlight-style'] || slideshow.getHighlightStyle();
@@ -143,7 +143,7 @@ function styleContentElement(slideshow: Slideshow, element: HTMLElement, propert
 
 function createNotesElement(slideshow: Slideshow, notes: unknown[]): HTMLElement {
   const element = document.createElement('div');
-  element.className = 'remark-slide-notes';
+  element.className = 'remark-slide-notes mdeck-slide-notes';
 
   const renderer = slideshow.getMarkdownRenderer();
   if (renderer) {
@@ -170,7 +170,7 @@ function highlightCodeBlocks(content: HTMLElement, slideshow: Slideshow): void {
     if (block.className === '') block.className = slideshow.getHighlightLanguage();
 
     if (block.parentElement?.tagName !== 'PRE') {
-      block.classList.add('remark-inline-code');
+      block.classList.add('remark-inline-code', 'mdeck-inline-code');
       if (highlightInline) highlighter.highlightElement(block);
       return;
     }
@@ -185,7 +185,7 @@ function highlightCodeBlocks(content: HTMLElement, slideshow: Slideshow): void {
     if (highlightLines) highlightBlockLines(block, meta.highlightedLines);
     if (highlightSpans) highlightBlockSpans(block, highlightSpans);
 
-    block.classList.add('remark-code');
+    block.classList.add('remark-code', 'mdeck-code');
   });
 }
 
@@ -199,13 +199,13 @@ function extractMetadata(block: HTMLElement): { highlightedLines: number[] } {
 }
 
 function wrapLines(block: HTMLElement): void {
-  const lines = block.innerHTML.split(/\r?\n/).map((line) => `<div class="remark-code-line">${line}</div>`);
+  const lines = block.innerHTML.split(/\r?\n/).map((line) => `<div class="remark-code-line mdeck-code-line">${line}</div>`);
   if (lines.length && lines[lines.length - 1].includes('><')) lines.pop();
   block.innerHTML = lines.join('');
 }
 
 function highlightBlockLines(block: HTMLElement, lines: number[]): void {
-  lines.forEach((i) => (block.childNodes[i] as HTMLElement).classList.add('remark-code-line-highlighted'));
+  lines.forEach((i) => (block.childNodes[i] as HTMLElement).classList.add('remark-code-line-highlighted', 'mdeck-code-line-highlighted'));
 }
 
 function highlightBlockSpans(block: HTMLElement, highlightSpans: boolean | RegExp): void {
@@ -222,7 +222,7 @@ function highlightBlockSpans(block: HTMLElement, highlightSpans: boolean | RegEx
     if (node instanceof HTMLElement) {
       node.innerHTML = node.innerHTML.replace(pattern, (m, e, c) => {
         if (e === '\\') return m.slice(1);
-        return e + `<span class="remark-code-span-highlighted">${c}</span>`;
+        return e + `<span class="remark-code-span-highlighted mdeck-code-span-highlighted">${c}</span>`;
       });
     }
   });

--- a/src/mdeck/views/slideshowView.ts
+++ b/src/mdeck/views/slideshowView.ts
@@ -37,7 +37,9 @@ export class SlideshowView {
     events.on('slidesChanged', () => this.updateSlideViews());
 
     events.on('hideSlide', (slideIndex: number) => {
-      Array.from(this.elementArea.getElementsByClassName('remark-fading')).forEach((s) => (s as HTMLElement).classList.remove('remark-fading'));
+      Array.from(this.elementArea.getElementsByClassName('remark-fading')).forEach((s) => {
+        (s as HTMLElement).classList.remove('remark-fading', 'mdeck-fading');
+      });
       this.hideSlide(slideIndex);
     });
 
@@ -45,7 +47,7 @@ export class SlideshowView {
 
     events.on('forcePresenterMode', () => {
       if (!this.containerElement.classList.contains('remark-presenter-mode')) {
-        this.containerElement.classList.toggle('remark-presenter-mode');
+        this.containerElement.classList.add('remark-presenter-mode', 'mdeck-presenter-mode');
         this.scaleElements();
         printing.setPageOrientation('landscape');
       }
@@ -53,22 +55,38 @@ export class SlideshowView {
 
     events.on('togglePresenterMode', () => {
       this.containerElement.classList.toggle('remark-presenter-mode');
+      this.containerElement.classList.toggle('mdeck-presenter-mode');
       this.scaleElements();
       events.emit('toggledPresenter', this.slideshow.getCurrentSlideIndex() + 1);
       printing.setPageOrientation(this.containerElement.classList.contains('remark-presenter-mode') ? 'portrait' : 'landscape');
     });
 
-    events.on('toggleHelp', () => this.containerElement.classList.toggle('remark-help-mode'));
-    events.on('toggleBlackout', () => this.containerElement.classList.toggle('remark-blackout-mode'));
-    events.on('toggleMirrored', () => this.containerElement.classList.toggle('remark-mirrored-mode'));
-
-    events.on('hideOverlay', () => {
-      this.containerElement.classList.remove('remark-blackout-mode');
-      this.containerElement.classList.remove('remark-help-mode');
+    events.on('toggleHelp', () => {
+      this.containerElement.classList.toggle('remark-help-mode');
+      this.containerElement.classList.toggle('mdeck-help-mode');
+    });
+    events.on('toggleBlackout', () => {
+      this.containerElement.classList.toggle('remark-blackout-mode');
+      this.containerElement.classList.toggle('mdeck-blackout-mode');
+    });
+    events.on('toggleMirrored', () => {
+      this.containerElement.classList.toggle('remark-mirrored-mode');
+      this.containerElement.classList.toggle('mdeck-mirrored-mode');
     });
 
-    events.on('pause', () => this.containerElement.classList.toggle('remark-pause-mode'));
-    events.on('resume', () => this.containerElement.classList.toggle('remark-pause-mode'));
+    events.on('hideOverlay', () => {
+      this.containerElement.classList.remove('remark-blackout-mode', 'mdeck-blackout-mode');
+      this.containerElement.classList.remove('remark-help-mode', 'mdeck-help-mode');
+    });
+
+    events.on('pause', () => {
+      this.containerElement.classList.toggle('remark-pause-mode');
+      this.containerElement.classList.toggle('mdeck-pause-mode');
+    });
+    events.on('resume', () => {
+      this.containerElement.classList.toggle('remark-pause-mode');
+      this.containerElement.classList.toggle('mdeck-pause-mode');
+    });
 
     this.handleFullscreen();
   }
@@ -79,10 +97,10 @@ export class SlideshowView {
 
   configureContainerElement(element: HTMLElement): void {
     this.containerElement = element;
-    element.classList.add('remark-container');
+    element.classList.add('remark-container', 'mdeck-container');
 
     if (element === this.dom.getBodyElement()) {
-      this.dom.getHTMLElement().classList.add('remark-container');
+      this.dom.getHTMLElement().classList.add('remark-container', 'mdeck-container');
       forwardEvents(this.events, window, ['hashchange', 'resize', 'keydown', 'keypress', 'mousewheel', 'message', 'DOMMouseScroll']);
       forwardEvents(this.events, element, ['touchstart', 'touchmove', 'touchend', 'click', 'contextmenu']);
     } else {
@@ -100,16 +118,16 @@ export class SlideshowView {
 
   configureChildElements(): void {
     this.containerElement.innerHTML += containerLayout;
-    this.elementArea = this.containerElement.getElementsByClassName('remark-slides-area')[0] as HTMLElement;
-    this.previewArea = this.containerElement.getElementsByClassName('remark-preview-area')[0] as HTMLElement;
-    this.notesArea = this.containerElement.getElementsByClassName('remark-notes-area')[0] as HTMLElement;
+    this.elementArea = this.containerElement.getElementsByClassName('mdeck-slides-area')[0] as HTMLElement;
+    this.previewArea = this.containerElement.getElementsByClassName('mdeck-preview-area')[0] as HTMLElement;
+    this.notesArea = this.containerElement.getElementsByClassName('mdeck-notes-area')[0] as HTMLElement;
 
     void new NotesView(this.events, this.notesArea, () => this.slideViews);
 
-    this.backdropElement = this.containerElement.getElementsByClassName('remark-backdrop')[0] as HTMLElement;
-    this.helpElement = this.containerElement.getElementsByClassName('remark-help')[0] as HTMLElement;
-    this.timerElement = this.notesArea.getElementsByClassName('remark-toolbar-timer')[0] as HTMLElement;
-    this.pauseElement = this.containerElement.getElementsByClassName('remark-pause')[0] as HTMLElement;
+    this.backdropElement = this.containerElement.getElementsByClassName('mdeck-backdrop')[0] as HTMLElement;
+    this.helpElement = this.containerElement.getElementsByClassName('mdeck-help')[0] as HTMLElement;
+    this.timerElement = this.notesArea.getElementsByClassName('mdeck-toolbar-timer')[0] as HTMLElement;
+    this.pauseElement = this.containerElement.getElementsByClassName('mdeck-pause')[0] as HTMLElement;
 
     this.events.on('propertiesChanged', (changes: Record<string, unknown>) => {
       if ('ratio' in changes) this.updateDimensions();

--- a/src/styles/mdeck.css
+++ b/src/styles/mdeck.css
@@ -1,119 +1,138 @@
 /* Container */
-html.remark-container, body.remark-container {
+html.remark-container, body.remark-container,
+html.mdeck-container, body.mdeck-container {
   height: 100%;
   width: 100%;
   -webkit-print-color-adjust: exact;
 }
-.remark-container {
+.remark-container, .mdeck-container {
   background: #d7d8d2;
   margin: 0;
   overflow: hidden;
 }
-.remark-container:focus {
+.remark-container:focus, .mdeck-container:focus {
   outline-style: solid;
   outline-width: 1px;
 }
-.remark-container:-webkit-full-screen { width: 100%; height: 100%; }
+.remark-container:-webkit-full-screen, .mdeck-container:-webkit-full-screen { width: 100%; height: 100%; }
 body:-webkit-full-screen { background: #000; }
 body:-moz-full-screen { background: #000; }
 body:fullscreen { background: #000; }
 
 /* Slides */
-.remark-slides-area { position: relative; height: 100%; width: 100%; }
-.remark-slide-container { display: none; position: absolute; height: 100%; width: 100%; page-break-after: always; }
-.remark-slide-scaler {
+.remark-slides-area, .mdeck-slides-area { position: relative; height: 100%; width: 100%; }
+.remark-slide-container, .mdeck-slide-container { display: none; position: absolute; height: 100%; width: 100%; page-break-after: always; }
+.remark-slide-scaler, .mdeck-slide-scaler {
   background-color: transparent; overflow: auto; position: absolute;
   -webkit-transform-origin: top left; -moz-transform-origin: top left; transform-origin: top-left;
   -moz-box-shadow: 0 0 30px #888; -webkit-box-shadow: 0 0 30px #888; box-shadow: 0 0 30px #888;
 }
-.remark-slide { height: 100%; width: 100%; display: table; table-layout: fixed; position: relative; }
-.remark-slide > .left   { text-align: left; }
-.remark-slide > .center { text-align: center; }
-.remark-slide > .right  { text-align: right; }
-.remark-slide > .top    { vertical-align: top; }
-.remark-slide > .middle { vertical-align: middle; }
-.remark-slide > .bottom { vertical-align: bottom; }
-.remark-slide-content {
+.remark-slide, .mdeck-slide { height: 100%; width: 100%; display: table; table-layout: fixed; position: relative; }
+.remark-slide > .left,   .mdeck-slide > .left   { text-align: left; }
+.remark-slide > .center, .mdeck-slide > .center { text-align: center; }
+.remark-slide > .right,  .mdeck-slide > .right  { text-align: right; }
+.remark-slide > .top,    .mdeck-slide > .top    { vertical-align: top; }
+.remark-slide > .middle, .mdeck-slide > .middle { vertical-align: middle; }
+.remark-slide > .bottom, .mdeck-slide > .bottom { vertical-align: bottom; }
+.remark-slide-content, .mdeck-slide-content {
   background-color: #fff; background-position: center; background-repeat: no-repeat;
   display: table-cell; font-size: 20px; padding: 1em 4em 1em 4em;
 }
-.remark-slide-content h1 { font-size: 55px; }
-.remark-slide-content h2 { font-size: 45px; }
-.remark-slide-content h3 { font-size: 35px; }
-.remark-slide-content .left  { display: block; text-align: left; }
-.remark-slide-content .center { display: block; text-align: center; }
-.remark-slide-content .right { display: block; text-align: right; }
-.remark-slide-number { bottom: 12px; opacity: 0.5; position: absolute; right: 20px; }
-.remark-slide-notes { border-top: 3px solid black; position: absolute; display: none; }
-.remark-code { font-size: 18px; }
-.remark-code-line { min-height: 1em; }
-.remark-code-line-highlighted { background-color: rgba(255,255,0,0.5); }
-.remark-code-span-highlighted { background-color: rgba(255,255,0,0.5); padding: 1px 2px 2px 2px; }
-.remark-visible { display: block; z-index: 2; }
-.remark-fading { display: block; z-index: 1; }
-.remark-fading .remark-slide-scaler { -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; }
+.remark-slide-content h1, .mdeck-slide-content h1 { font-size: 55px; }
+.remark-slide-content h2, .mdeck-slide-content h2 { font-size: 45px; }
+.remark-slide-content h3, .mdeck-slide-content h3 { font-size: 35px; }
+.remark-slide-content .left,   .mdeck-slide-content .left   { display: block; text-align: left; }
+.remark-slide-content .center, .mdeck-slide-content .center { display: block; text-align: center; }
+.remark-slide-content .right,  .mdeck-slide-content .right  { display: block; text-align: right; }
+.remark-slide-number, .mdeck-slide-number { bottom: 12px; opacity: 0.5; position: absolute; right: 20px; }
+.remark-slide-notes, .mdeck-slide-notes { border-top: 3px solid black; position: absolute; display: none; }
+.remark-code, .mdeck-code { font-size: 18px; }
+.remark-code-line, .mdeck-code-line { min-height: 1em; }
+.remark-code-line-highlighted, .mdeck-code-line-highlighted { background-color: rgba(255,255,0,0.5); }
+.remark-code-span-highlighted, .mdeck-code-span-highlighted { background-color: rgba(255,255,0,0.5); padding: 1px 2px 2px 2px; }
+.remark-visible, .mdeck-visible { display: block; z-index: 2; }
+.remark-fading, .mdeck-fading { display: block; z-index: 1; }
+.remark-fading .remark-slide-scaler, .remark-fading .mdeck-slide-scaler,
+.mdeck-fading .remark-slide-scaler, .mdeck-fading .mdeck-slide-scaler { -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; }
 
 /* Backdrop */
-.remark-backdrop { position: absolute; top: 0; bottom: 0; left: 0; right: 0; display: none; background: #000; z-index: 2; }
+.remark-backdrop, .mdeck-backdrop { position: absolute; top: 0; bottom: 0; left: 0; right: 0; display: none; background: #000; z-index: 2; }
 
 /* Pause */
-.remark-pause { bottom: 0; top: 0; right: 0; left: 0; display: none; position: absolute; z-index: 1000; }
-.remark-pause .remark-pause-lozenge { margin-top: 30%; text-align: center; }
-.remark-pause .remark-pause-lozenge span { color: white; background: black; border: 2px solid black; border-radius: 20px; padding: 20px 30px; font-family: Helvetica,arial,freesans,clean,sans-serif; font-size: 42pt; font-weight: bold; }
-.remark-container.remark-presenter-mode.remark-pause-mode .remark-pause { display: block; }
-.remark-container.remark-presenter-mode.remark-pause-mode .remark-backdrop { display: block; opacity: 0.5; }
+.remark-pause, .mdeck-pause { bottom: 0; top: 0; right: 0; left: 0; display: none; position: absolute; z-index: 1000; }
+.remark-pause .remark-pause-lozenge, .mdeck-pause .mdeck-pause-lozenge { margin-top: 30%; text-align: center; }
+.remark-pause .remark-pause-lozenge span, .mdeck-pause .mdeck-pause-lozenge span { color: white; background: black; border: 2px solid black; border-radius: 20px; padding: 20px 30px; font-family: Helvetica,arial,freesans,clean,sans-serif; font-size: 42pt; font-weight: bold; }
+.remark-container.remark-presenter-mode.remark-pause-mode .remark-pause,
+.mdeck-container.mdeck-presenter-mode.mdeck-pause-mode .mdeck-pause { display: block; }
+.remark-container.remark-presenter-mode.remark-pause-mode .remark-backdrop,
+.mdeck-container.mdeck-presenter-mode.mdeck-pause-mode .mdeck-backdrop { display: block; opacity: 0.5; }
 
 /* Help */
-.remark-help { bottom: 0; top: 0; right: 0; left: 0; display: none; position: absolute; z-index: 1000; -webkit-transform-origin: top left; -moz-transform-origin: top left; transform-origin: top-left; }
-.remark-help .remark-help-content { color: white; font-family: Helvetica,arial,freesans,clean,sans-serif; font-size: 12pt; position: absolute; top: 5%; bottom: 10%; height: 10%; left: 5%; width: 90%; }
-.remark-help .remark-help-content h1 { font-size: 36px; }
-.remark-help .remark-help-content td { color: white; font-size: 12pt; padding: 10px; }
-.remark-help .remark-help-content td:first-child { padding-left: 0; }
-.remark-help .remark-help-content .key { background: white; color: black; min-width: 1em; display: inline-block; padding: 3px 6px; text-align: center; border-radius: 4px; font-size: 14px; }
-.remark-help .dismiss { top: 85%; }
-.remark-container.remark-help-mode .remark-help { display: block; }
-.remark-container.remark-help-mode .remark-backdrop { display: block; opacity: 0.95; }
+.remark-help, .mdeck-help { bottom: 0; top: 0; right: 0; left: 0; display: none; position: absolute; z-index: 1000; -webkit-transform-origin: top left; -moz-transform-origin: top left; transform-origin: top-left; }
+.remark-help .remark-help-content, .mdeck-help .mdeck-help-content { color: white; font-family: Helvetica,arial,freesans,clean,sans-serif; font-size: 12pt; position: absolute; top: 5%; bottom: 10%; height: 10%; left: 5%; width: 90%; }
+.remark-help .remark-help-content h1, .mdeck-help .mdeck-help-content h1 { font-size: 36px; }
+.remark-help .remark-help-content td, .mdeck-help .mdeck-help-content td { color: white; font-size: 12pt; padding: 10px; }
+.remark-help .remark-help-content td:first-child, .mdeck-help .mdeck-help-content td:first-child { padding-left: 0; }
+.remark-help .remark-help-content .key, .mdeck-help .mdeck-help-content .key { background: white; color: black; min-width: 1em; display: inline-block; padding: 3px 6px; text-align: center; border-radius: 4px; font-size: 14px; }
+.remark-help .dismiss, .mdeck-help .dismiss { top: 85%; }
+.remark-container.remark-help-mode .remark-help,
+.mdeck-container.mdeck-help-mode .mdeck-help { display: block; }
+.remark-container.remark-help-mode .remark-backdrop,
+.mdeck-container.mdeck-help-mode .mdeck-backdrop { display: block; opacity: 0.95; }
 
 /* Presenter mode */
-.remark-preview-area { bottom: 2%; left: 2%; display: none; opacity: 0.5; position: absolute; height: 47.25%; width: 48%; }
-.remark-preview-area .remark-slide-container { display: block; }
-.remark-notes-area { background: #fff; bottom: 0; color: black; display: none; left: 52%; overflow: hidden; position: absolute; right: 0; top: 0; }
-.remark-notes-area .remark-top-area { height: 50px; left: 20px; position: absolute; right: 10px; top: 10px; }
-.remark-notes-area .remark-bottom-area { position: absolute; top: 75px; bottom: 10px; left: 20px; right: 10px; }
-.remark-notes-area .remark-bottom-area .remark-toggle { display: block; text-decoration: none; font-family: Helvetica,arial,freesans,clean,sans-serif; height: 21px; font-size: 0.75em; text-transform: uppercase; color: #ccc; }
-.remark-notes-area .remark-bottom-area .remark-notes-current-area { height: 70%; position: relative; }
-.remark-notes-area .remark-bottom-area .remark-notes-current-area .remark-notes { clear: both; border-top: 1px solid #f5f5f5; position: absolute; top: 22px; bottom: 0; left: 0; right: 0; overflow-y: auto; margin-bottom: 20px; padding-top: 10px; }
-.remark-notes-area .remark-bottom-area .remark-notes-preview-area { height: 30%; position: relative; }
-.remark-notes-area .remark-bottom-area .remark-notes-preview-area .remark-notes-preview { border-top: 1px solid #f5f5f5; position: absolute; top: 22px; bottom: 0; left: 0; right: 0; overflow-y: auto; }
+.remark-preview-area, .mdeck-preview-area { bottom: 2%; left: 2%; display: none; opacity: 0.5; position: absolute; height: 47.25%; width: 48%; }
+.remark-preview-area .remark-slide-container, .mdeck-preview-area .mdeck-slide-container { display: block; }
+.remark-notes-area, .mdeck-notes-area { background: #fff; bottom: 0; color: black; display: none; left: 52%; overflow: hidden; position: absolute; right: 0; top: 0; }
+.remark-notes-area .remark-top-area, .mdeck-notes-area .mdeck-top-area { height: 50px; left: 20px; position: absolute; right: 10px; top: 10px; }
+.remark-notes-area .remark-bottom-area, .mdeck-notes-area .mdeck-bottom-area { position: absolute; top: 75px; bottom: 10px; left: 20px; right: 10px; }
+.remark-notes-area .remark-bottom-area .remark-toggle, .mdeck-notes-area .mdeck-bottom-area .mdeck-toggle { display: block; text-decoration: none; font-family: Helvetica,arial,freesans,clean,sans-serif; height: 21px; font-size: 0.75em; text-transform: uppercase; color: #ccc; }
+.remark-notes-area .remark-bottom-area .remark-notes-current-area, .mdeck-notes-area .mdeck-bottom-area .mdeck-notes-current-area { height: 70%; position: relative; }
+.remark-notes-area .remark-bottom-area .remark-notes-current-area .remark-notes, .mdeck-notes-area .mdeck-bottom-area .mdeck-notes-current-area .mdeck-notes { clear: both; border-top: 1px solid #f5f5f5; position: absolute; top: 22px; bottom: 0; left: 0; right: 0; overflow-y: auto; margin-bottom: 20px; padding-top: 10px; }
+.remark-notes-area .remark-bottom-area .remark-notes-preview-area, .mdeck-notes-area .mdeck-bottom-area .mdeck-notes-preview-area { height: 30%; position: relative; }
+.remark-notes-area .remark-bottom-area .remark-notes-preview-area .remark-notes-preview, .mdeck-notes-area .mdeck-bottom-area .mdeck-notes-preview-area .mdeck-notes-preview { border-top: 1px solid #f5f5f5; position: absolute; top: 22px; bottom: 0; left: 0; right: 0; overflow-y: auto; }
 .remark-notes-area .remark-bottom-area .remark-notes > *:first-child,
-.remark-notes-area .remark-bottom-area .remark-notes-preview > *:first-child { margin-top: 5px; }
+.remark-notes-area .remark-bottom-area .remark-notes-preview > *:first-child,
+.mdeck-notes-area .mdeck-bottom-area .mdeck-notes > *:first-child,
+.mdeck-notes-area .mdeck-bottom-area .mdeck-notes-preview > *:first-child { margin-top: 5px; }
 .remark-notes-area .remark-bottom-area .remark-notes > *:last-child,
-.remark-notes-area .remark-bottom-area .remark-notes-preview > *:last-child { margin-bottom: 0; }
+.remark-notes-area .remark-bottom-area .remark-notes-preview > *:last-child,
+.mdeck-notes-area .mdeck-bottom-area .mdeck-notes > *:last-child,
+.mdeck-notes-area .mdeck-bottom-area .mdeck-notes-preview > *:last-child { margin-bottom: 0; }
 
 /* Toolbar */
-.remark-toolbar { color: #979892; vertical-align: middle; }
-.remark-toolbar .remark-toolbar-link { border: 2px solid #d7d8d2; color: #979892; display: inline-block; padding: 2px; text-decoration: none; text-align: center; min-width: 20px; }
-.remark-toolbar .remark-toolbar-link:hover { border-color: #979892; color: #676862; }
-.remark-toolbar .remark-toolbar-timer { border: 2px solid black; border-radius: 10px; background: black; color: white; display: inline-block; float: right; padding: 5px 10px; font-family: sans-serif; font-weight: bold; font-size: 175%; text-decoration: none; text-align: center; }
+.remark-toolbar, .mdeck-toolbar { color: #979892; vertical-align: middle; }
+.remark-toolbar .remark-toolbar-link, .mdeck-toolbar .mdeck-toolbar-link { border: 2px solid #d7d8d2; color: #979892; display: inline-block; padding: 2px; text-decoration: none; text-align: center; min-width: 20px; }
+.remark-toolbar .remark-toolbar-link:hover, .mdeck-toolbar .mdeck-toolbar-link:hover { border-color: #979892; color: #676862; }
+.remark-toolbar .remark-toolbar-timer, .mdeck-toolbar .mdeck-toolbar-timer { border: 2px solid black; border-radius: 10px; background: black; color: white; display: inline-block; float: right; padding: 5px 10px; font-family: sans-serif; font-weight: bold; font-size: 175%; text-decoration: none; text-align: center; }
 
-.remark-container.remark-presenter-mode .remark-slides-area { top: 2%; left: 2%; height: 47.25%; width: 48%; }
-.remark-container.remark-presenter-mode .remark-preview-area { display: block; }
-.remark-container.remark-presenter-mode .remark-notes-area { display: block; }
+.remark-container.remark-presenter-mode .remark-slides-area,
+.mdeck-container.mdeck-presenter-mode .mdeck-slides-area { top: 2%; left: 2%; height: 47.25%; width: 48%; }
+.remark-container.remark-presenter-mode .remark-preview-area,
+.mdeck-container.mdeck-presenter-mode .mdeck-preview-area { display: block; }
+.remark-container.remark-presenter-mode .remark-notes-area,
+.mdeck-container.mdeck-presenter-mode .mdeck-notes-area { display: block; }
 
 /* Blackout */
-.remark-container.remark-blackout-mode:not(.remark-presenter-mode) .remark-backdrop { display: block; opacity: 0.99; }
+.remark-container.remark-blackout-mode:not(.remark-presenter-mode) .remark-backdrop,
+.mdeck-container.mdeck-blackout-mode:not(.mdeck-presenter-mode) .mdeck-backdrop { display: block; opacity: 0.99; }
 
 /* Mirrored */
-.remark-container.remark-mirrored-mode:not(.remark-presenter-mode) .remark-slides-area { -webkit-transform: scaleX(-1); -moz-transform: scaleX(-1); -ms-transform: scaleX(-1); -o-transform: scaleX(-1); }
+.remark-container.remark-mirrored-mode:not(.remark-presenter-mode) .remark-slides-area,
+.mdeck-container.mdeck-mirrored-mode:not(.mdeck-presenter-mode) .mdeck-slides-area { -webkit-transform: scaleX(-1); -moz-transform: scaleX(-1); -ms-transform: scaleX(-1); -o-transform: scaleX(-1); }
 
 /* Print */
 @media print {
-  .remark-container { overflow: visible; background-color: #fff; }
-  .remark-container.remark-presenter-mode .remark-slides-area { top: 0; left: 0; height: 100%; width: 681px; }
+  .remark-container, .mdeck-container { overflow: visible; background-color: #fff; }
+  .remark-container.remark-presenter-mode .remark-slides-area,
+  .mdeck-container.mdeck-presenter-mode .mdeck-slides-area { top: 0; left: 0; height: 100%; width: 681px; }
   .remark-container.remark-presenter-mode .remark-preview-area,
-  .remark-container.remark-presenter-mode .remark-notes-area { display: none; }
-  .remark-container.remark-presenter-mode .remark-slide-notes { display: block; margin-left: 30px; width: 621px; }
-  .remark-slide-container { display: block; position: relative; }
-  .remark-slide-scaler { -moz-box-shadow: none; -webkit-box-shadow: none; -webkit-transform-origin: initial; box-shadow: none; }
+  .remark-container.remark-presenter-mode .remark-notes-area,
+  .mdeck-container.mdeck-presenter-mode .mdeck-preview-area,
+  .mdeck-container.mdeck-presenter-mode .mdeck-notes-area { display: none; }
+  .remark-container.remark-presenter-mode .remark-slide-notes,
+  .mdeck-container.mdeck-presenter-mode .mdeck-slide-notes { display: block; margin-left: 30px; width: 621px; }
+  .remark-slide-container, .mdeck-slide-container { display: block; position: relative; }
+  .remark-slide-scaler, .mdeck-slide-scaler { -moz-box-shadow: none; -webkit-box-shadow: none; -webkit-transform-origin: initial; box-shadow: none; }
 }
 @page { margin: 0; }


### PR DESCRIPTION
## Summary

Introduces `mdeck-*` CSS class names as the canonical prefix for all elements created by mdeck, while keeping full backward compatibility with existing `remark-*` selectors.

## What changed

### CSS (`src/styles/mdeck.css`)
Every `remark-*` selector now has a comma-separated `mdeck-*` equivalent, so stylesheets targeting either prefix work without changes.

### HTML template (`src/mdeck/resources.ts`)
Every element in the container layout now carries both `remark-*` and `mdeck-*` class names.

### TypeScript
- **slideView**: dual classes on container, scaler, slide, content, notes, code elements (inline code, code blocks, code lines, highlighted lines/spans)
- **slideshowView**: dual classes on container element; all mode-class toggles (presenter, help, blackout, mirrored, pause) updated; internal `getElementsByClassName` queries migrated to `mdeck-*`
- **notesView**: internal queries migrated to `mdeck-*`
- **slide-number**: dual class on the slide number element
- **styler**: stylesheet title changed to `'mdeck'`; lookup falls back to `'remark'` for backward compat
- **location**: presenter-mode detection updated to `mdeck-presenter-mode`

## Backward compatibility

- All `remark-*` class names remain on every element — existing CSS and JS targeting those classes continues to work
- Stylesheet lookup accepts both `'mdeck'` and `'remark'` titles
- No breaking changes to the public API