### PR TITLE
fix: recognise ??? notes separator with trailing whitespace

### DIFF
--- a/src/__tests__/lexer.test.ts
+++ b/src/__tests__/lexer.test.ts
@@ -54,6 +54,14 @@ describe('Lexer', () => {
     it('recognizes ??? notes separator', () => {
       expect(lexer.lex('\n???\n')).toEqual([{ type: 'notes_separator', text: '???' }]);
     });
+
+    it('recognizes ??? with trailing spaces (issue #1)', () => {
+      expect(lexer.lex('\n???   \n')).toEqual([{ type: 'notes_separator', text: '???' }]);
+    });
+
+    it('recognizes ??? with trailing tabs (issue #1)', () => {
+      expect(lexer.lex('\n???\t\n')).toEqual([{ type: 'notes_separator', text: '???' }]);
+    });
   });
 
   describe('code blocks', () => {

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -69,6 +69,18 @@ describe('Parser', () => {
     it('removes notes from slide content', () => {
       expect(parser.parse('content\n???\nnotes')[0].content).toEqual(['content']);
     });
+
+    it('parses notes after ??? with trailing spaces (issue #1)', () => {
+      const slide = parser.parse('content\n???   \nnotes')[0];
+      expect(slide.notes).toEqual(['notes']);
+      expect(slide.content).toEqual(['content']);
+    });
+
+    it('parses notes after ??? with trailing tab (issue #1)', () => {
+      const slide = parser.parse('content\n???\t\nnotes')[0];
+      expect(slide.notes).toEqual(['notes']);
+      expect(slide.content).toEqual(['content']);
+    });
   });
 
   describe('fenced code blocks', () => {

--- a/src/mdeck/lexer.ts
+++ b/src/mdeck/lexer.ts
@@ -29,7 +29,7 @@ const regexByName: Record<string, RegExp> = {
   MACRO: /!\[:([^\] ]+)([^\]]*)\](?:\(([^\)]*)\))?/,
   SLIDE_SEPARATOR: /(?:^|\n)(---|<!--\s*break\s*-->)(?:\n|$)/,
   FRAGMENT_SEPARATOR: /(?:^|\n)(--)(?![^\n])/,
-  NOTES_SEPARATOR: /(?:^|\n)(\?{3})(?:\n|$)/,
+  NOTES_SEPARATOR: /(?:^|\n)(\?{3})[ \t]*(?:\n|$)/,
 };
 
 function replace(regex: RegExp, replacements: Record<string, RegExp>): RegExp {


### PR DESCRIPTION
## Summary

- One-character regex fix in `lexer.ts`: adds `[ \t]*` before the end anchor of the `NOTES_SEPARATOR` pattern
- Adds 2 lexer tests (trailing spaces, trailing tab)
- Adds 2 parser-level tests confirming notes are correctly split from content in both cases

## Root cause

```ts
// before
NOTES_SEPARATOR: /(?:^|\n)(\?{3})(?:\n|$)/,

// after
NOTES_SEPARATOR: /(?:^|\n)(\?{3})[ \t]*(?:\n|$)/,
```

Any trailing space or tab on the `???` line prevented the regex from matching, so the separator was not recognised and all notes were rendered as regular slide content.

Closes #1