### PR TITLE
fix: highlight backtick spans that start at the beginning of a line

### DIFF
--- a/src/__tests__/highlightSpans.test.ts
+++ b/src/__tests__/highlightSpans.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+
+// Test the highlight-spans regex behaviour directly.
+// The bug (issue #2): a backtick span at the very start of a line was not
+// recognised because the pattern required a non-backtick character before the
+// opening backtick.  The fix adds `^` as an alternative via the `m` flag.
+
+function applyHighlightPattern(html: string): string {
+  // Mirrors the fixed pattern in highlightBlockSpans (highlightSpans === true).
+  const pattern = /(^|[^`])`([^`]+?)`/gm;
+  return html.replace(pattern, (m, e, c) => {
+    if (e === '\\') return m.slice(1);
+    return e + `<span class="remark-code-span-highlighted">${c}</span>`;
+  });
+}
+
+describe('highlightSpans regex (issue #2)', () => {
+  it('highlights a span preceded by a non-backtick character', () => {
+    const result = applyHighlightPattern('call `method`(arg)');
+    expect(result).toContain('<span class="remark-code-span-highlighted">method</span>');
+  });
+
+  it('highlights a span at the very start of a string', () => {
+    const result = applyHighlightPattern('`highlightedMethod`(arg1, arg2)');
+    expect(result).toContain('<span class="remark-code-span-highlighted">highlightedMethod</span>');
+  });
+
+  it('highlights a span at the start of a new line', () => {
+    const html = 'normalMethod(a)\n`highlightedMethod`(b)';
+    const result = applyHighlightPattern(html);
+    expect(result).toContain('<span class="remark-code-span-highlighted">highlightedMethod</span>');
+    expect(result).toContain('normalMethod(a)');
+  });
+
+  it('does not double-highlight adjacent backtick spans', () => {
+    const result = applyHighlightPattern('`a` and `b`');
+    expect(result).toContain('<span class="remark-code-span-highlighted">a</span>');
+    expect(result).toContain('<span class="remark-code-span-highlighted">b</span>');
+  });
+
+  it('does not highlight a backtick span that is escaped', () => {
+    const result = applyHighlightPattern('\\`notHighlighted`');
+    expect(result).not.toContain('remark-code-span-highlighted');
+  });
+
+  it('does not treat fenced code delimiters (```) as highlight spans', () => {
+    const result = applyHighlightPattern('```js\ncode\n```');
+    expect(result).not.toContain('remark-code-span-highlighted');
+  });
+});

--- a/src/mdeck/views/slideView.ts
+++ b/src/mdeck/views/slideView.ts
@@ -211,10 +211,10 @@ function highlightBlockLines(block: HTMLElement, lines: number[]): void {
 function highlightBlockSpans(block: HTMLElement, highlightSpans: boolean | RegExp): void {
   let pattern: RegExp;
   if (highlightSpans === true) {
-    pattern = /([^`])`([^`]+?)`/g;
+    pattern = /(^|[^`])`([^`]+?)`/gm;
   } else if (highlightSpans instanceof RegExp) {
     if (!highlightSpans.global) throw new Error('highlightSpans RegExp must have /g flag');
-    pattern = new RegExp('([^])' + highlightSpans.source, highlightSpans.flags || 'g');
+    pattern = new RegExp('(^|[\\s\\S])' + highlightSpans.source, (highlightSpans.flags || 'g') + 'm');
   } else {
     throw new Error('Illegal value for highlightSpans');
   }


### PR DESCRIPTION
## Summary

- Fixes the `highlightSpans` regex in `slideView.ts` so that backtick spans at the start of a line (or the start of the HTML string) are matched and highlighted correctly
- Applies the same fix to the custom `RegExp` path
- Adds a new test file `highlightSpans.test.ts` with 6 cases covering the bug scenario and surrounding edge cases

## Root cause

```ts
// before — requires a non-backtick character before the opening backtick
pattern = /([^`])`([^`]+?)`/g;

// after — also allows start-of-line as the "preceding context"
pattern = /(^|[^`])`([^`]+?)`/gm;
```

The original `([^\`])` group consumed exactly one character, so a span whose opening backtick was the first character on a line (or the first character in the string) never matched.

## Fix

Changed the leading group to `(^|[^\`])` and added the `m` (multiline) flag so `^` matches the start of every line, not just the start of the full string. The replacement callback already handles `e` being an empty string correctly — it simply prepends nothing.

Closes #2